### PR TITLE
Feat: impliment sparkinfer_cache_manager && layer_cache, add a new struct named sparkinfer_reload_plan

### DIFF
--- a/notes/spif_cache_worklog.md
+++ b/notes/spif_cache_worklog.md
@@ -1,6 +1,10 @@
-KV cache
+# KV cache
+
+## Part I: KV Cache 机制
 
 0. 在构建计算图的时候，store and get multi-decodes 全局的 ggml_tensors from kv_cache:
+
+```C++
         // llama-graph.cpp line 1542
         // store to KV cache
         {
@@ -14,16 +18,25 @@ KV cache
         ggml_tensor * q = q_cur;
         ggml_tensor * k = kv_self->get_k(ctx0, il);
         ggml_tensor * v = kv_self->get_v(ctx0, il);
+```
 
 1. 在 graph_build 中, kv_cache 通过 llama_graph_context 中的 memory 取出来实例化：
+
+```C++
         // llama-graph.cpp line 1540
         const llama_kv_cache_recurrent * kv_self = static_cast<const llama_kv_cache_recurrent *>(memory);
+```
 
 2. 这个 memory 在 llama_graph_context 初始化的时候通过 llm_graph_params 中的 memory 赋值
+
+```C++
         // llama-graph.cpp
         memory           (params.memory),
+```
 
 3. params 来自于 llama-context.cpp graph_build 的时候构建
+
+```C++
         llm_graph_result_ptr llama_context::graph_build(
                     ggml_context * ctx,
                     ggml_cgraph * gf,
@@ -46,11 +59,18 @@ KV cache
                         /*.cb          =*/ graph_get_cb(),
                     }, gf, gtype);
         }
-        因此，llama_context 里面有这个 memory 成员：
+```
+
+   因此，llama_context 里面有这个 memory 成员：
+
+```C++
         // llama-context.h
         std::unique_ptr<llama_memory_i> memory;
+```
 
 4. 这个 memory 成员在 llama-context 初始化的时候跟着初始化：
+
+```C++
         // llama-context.cpp:
         // init the memory module
         if (!hparams.vocab_only) {
@@ -62,15 +82,22 @@ KV cache
 
             memory.reset(model.create_memory(params_mem, cparams));
         }
+```
 
+## Part II: Sparkinfer Cache Manager
 
 下面仿照 kvcache 的管理加入 kvcache-like sparkinfer-cache-manager:
 
 1. 新建 memory 子类在 llama-context 中
-        std::unique_ptr<llama_memory_i> spif_cache_mng;
 
-2(对应上面 4). 在 llama-context 初始化时候初始这个 spif_cache_mng
+```C++
+        std::unique_ptr<llama_memory_i> spif_cache_mng;
+```
+
+2. (对应上面 4) 在 llama-context 初始化时候初始这个 spif_cache_mng
    仿照kvcache，spif_cache_mng 的初始化被 llama-model 里的函数调用
+
+```C++
         //llama-context.cpp
         // init sparkinfer_cache_manager if use sparkinfer
         if (!hparams.vocab_only && llama_use_sparkinfer(&model)) {
@@ -96,28 +123,30 @@ KV cache
 
                 return res;
         }
+```
 
 3. 下面完善 sparkinfer_cache_manager 的构造函数，以及类的成员构建
 
-        3.1 对于构造函数，目前传入的参数是 model 和 cparams 的引用，通过 model 足以初始化 layer_caches 中的 tensor 指针。
-            TODO: layer_caches 和 sparkinfer_cache_manager()的构造函数实现 in llama-sparkinfer.cpp
-        3.2 成员和成员函数的设计：
-                目前成员设计只是最简单的 ggml_tensor *， 用 private？
-                然后设计 get_xxx 和 reload_xxx? (注意：这里的 reload 不是真正的 reload 实现，只是标记这个节点要 reload，依旧是在 build_graph 过程中！)
+   1. 对于构造函数，目前传入的参数是 model 和 cparams 的引用，通过 model 足以初始化 layer_caches 中的 tensor 指针。  
+TODO: layer_caches 和 sparkinfer_cache_manager()的构造函数实现 in llama-sparkinfer.cpp
 
-4.
-        4.1 先把 sparkinfer_cache_manager 这个成员先加入 llama_graph_params定义中）
-        4.2 （对应上面 3）然后在构建 llama_graph_context 的时候由 llama_context 里面的 spif_cache_mng 指针赋值给 llama_graph_params
-        4.3 在 llama_graph_context 里面加入成员：
-                const llama_memory_i      * spif_cache;
-        4.3 （对应上面 2）再由 llama_graph_params 赋值给 llama_graph_context
-                spif_cache       (params.spif_cache)
+   2. 成员和成员函数的设计：  
+目前成员设计只是最简单的 ggml_tensor *， 用 private？  
+然后设计 get_xxx 和 reload_xxx? (注意：这里的 reload 不是真正的 reload 实现，只是标记这个节点要 reload，依旧是在 build_graph 过程中！)
 
-5. 1. 在 graph_build 中, kv_cache 通过 llama_graph_context 中的 memory 取出来实例化：
+4. 实现步骤
+   1. 先把 sparkinfer_cache_manager 这个成员先加入 llama_graph_params定义中
+   2. （对应上面 3）然后在构建 llama_graph_context 的时候由 llama_context 里面的 spif_cache_mng 指针赋值给 llama_graph_params  
+   3. 在 llama_graph_context 里面加入成员：  
+   `const llama_memory_i * spif_cache;`
+   4. （对应上面 2）再由 llama_graph_params 赋值给 llama_graph_context  
+   `spif_cache (params.spif_cache)`
+
+5. 在 graph_build 中, kv_cache 通过 llama_graph_context 中的 memory 取出来实例化：
+
+```C++
         // llama-graph.cpp line 871
         const sparkinfer_cache_manager * spif_cache = static_cast<const sparkinfer_cache_manager*>(spif_cache);
         const layer_cache * spif_layer = spif_cache ? spif_cache->get_layer_cache(il) : nullptr;
-
-
-
+```
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -5,6 +5,7 @@
 #include "llama-cparams.h"
 #include "llama-kv-cache.h"
 #include "llama-model.h"
+#include "llama-sparkinfer.h"
 
 #include <cassert>
 #include <cmath>
@@ -868,8 +869,8 @@ ggml_tensor * llm_graph_context::build_sparse_ffn(
                  ggml_tensor * input,
                          int   il) const{      
     
-        const sparkinfer_cache_manager * spif_cache = static_cast<const sparkinfer_cache_manager*>(spif_cache);
-        const layer_cache * spif_layer = spif_cache ? spif_cache->get_layer_cache(il) : nullptr;
+        const sparkinfer_cache_manager * spif_cache_manager = static_cast<const sparkinfer_cache_manager*>(this->spif_cache);
+        const layer_cache * spif_layer = spif_cache_manager ? spif_cache->get_layer_cache(il) : nullptr;
         
         const struct llama_layer *L      = &(model->layers[il]);
         const struct llama_layer *L_next = il == (n_layer - 1) ? nullptr : &(model->layers[il+1]);
@@ -893,10 +894,12 @@ ggml_tensor * llm_graph_context::build_sparse_ffn(
 
             R_next->sparse_idx = next_sparse_idx;
 
-            // GTODO[reload]: build reload
-            // if(!next_full_gpu){
-            //     ggml_tensor * done_reload = build_reload(ctx0, next_sparse_idx, L_next); // GTODO[reload] how do we use the done_reload tensor as prerequisite?
-            // }
+            if(!next_full_gpu){
+                ggml_tensor * done_reload = build_sparse_reload_group(ctx0, next_sparse_idx, L_next); 
+                // GTODO[reload] how do we use the done_reload tensor as prerequisite?
+                // [YPX] [C] 我的 AI 推荐我把 down_reload 修改为 new_gpu_neu_idx
+                // [YPX] [C] 然后这么写：R_next->gpu_neu_idx = done_reload;
+            }
         }
 
         // sparse_ffn  GTODO: use integrated kernel?
@@ -959,6 +962,17 @@ ggml_tensor * llm_graph_context::build_sparse_ffn(
         
         return cur;
     }
+
+
+ggml_tensor * build_sparse_reload_group(
+        ggml_context * ctx,
+        ggml_tensor * sparse_idx,
+        const struct llama_layer *L
+){
+    // Step 1: sparkinfer_cache_manager::plan_reload()，以获得更新方案
+    // Step 2: ggml_reload()，以构建 GGML_OP_RELOAD 节点，更新权重
+    // Step 3: 更新 CPU 上的 元数据，以及调用 ggml_cpy()，以更新 GPU 上的元数据
+}
 
 ggml_tensor * llm_graph_context::build_moe_ffn(
          ggml_tensor * cur,

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -221,16 +221,25 @@ struct llama_layer {
     struct ggml_tensor * ffn_pred_up_b       = nullptr; 
     struct ggml_tensor * ffn_pred_down_b     = nullptr; 
 
+    // [YPX] [GTODO] for group cache (need to be read from .gguf!)
+    int ffn_group_size = 0;
+    struct ggml_tensor * ffn_group_to_neurons_map   = nullptr;
+    struct ggml_tensor * ffn_neuron_to_group_map    = nullptr;
+
     // ffn slice on gpu
     struct ggml_tensor * ffn_gpu_gate       = nullptr;
     struct ggml_tensor * ffn_gpu_down_t     = nullptr;
     struct ggml_tensor * ffn_gpu_up         = nullptr;
+    struct ggml_tensor * ffn_gpu_gate_b     = nullptr;
+    struct ggml_tensor * ffn_gpu_up_b       = nullptr;
+    struct ggml_tensor * ffn_gpu_down_b     = nullptr;
 
     // ffn sparse infernece relevant 
     struct ggml_tensor * ffn_gpu_neu_idx          = nullptr; // on gpu
     struct ggml_tensor * ffn_gpu_neu_mask         = nullptr;
-    struct ggml_tensor * ffn_gpu_group_idx        = nullptr; // on gpu
-    struct ggml_tensor * ffn_gpu_group_mask       = nullptr;
+    // [YPX] [C] cache_manager 用不到，cpu/gpu 算子也用不到，故注释掉了
+    // struct ggml_tensor * ffn_gpu_group_idx        = nullptr; // on gpu
+    // struct ggml_tensor * ffn_gpu_group_mask       = nullptr;
     struct ggml_tensor * ffn_neuron_to_group_map  = nullptr;
     float gpu_offload_ratio = 0.0f;
     

--- a/src/llama-sparkinfer.cpp
+++ b/src/llama-sparkinfer.cpp
@@ -1,2 +1,262 @@
 #include "llama-sparkinfer.h"
 
+layer_cache::layer_cache(const llama_layer & layer, int64_t layer_idx, double dfr_decay, double dfr_bonus){
+
+    // ====================================================
+    // 1. initialize all member variables to default values
+    // ====================================================
+
+    // 1.1 layer idx and full_gpu
+    this->layer_idx = layer_idx;
+    this->full_gpu = layer.gpu_offload_ratio >= 1.0 ? true : false; // [YPX] [Q] 询问甘明昊：这样初始化是否正确？
+
+    // 1.2 init ffn_gpu_neu_idx/mask
+    this->ffn_gpu_neu_idx = layer.ffn_gpu_neu_idx;
+    this->ffn_gpu_neu_mask = layer.ffn_gpu_neu_mask;
+
+    // 1.3 init layer_(neuron/group)_(count/size/capacity)
+    this->layer_neuron_count    = ffn_gpu_neu_mask->ne[1];
+    this->layer_group_size      = layer.ffn_group_size;
+    this->layer_group_count     = layer_neuron_count / layer_group_size;
+    this->layer_neuron_capacity = ffn_gpu_neu_idx->ne[0];
+    this->layer_group_capacity  = layer_neuron_capacity / layer_group_size;
+    
+    // 1.4 init std::vector gpu_neu_idx/mask_vec
+    this->gpu_neu_idx_vec.resize(ffn_gpu_neu_idx->ne[0], 0);
+    memcpy(gpu_neu_idx_vec.data(), ffn_gpu_neu_idx->data, ffn_gpu_neu_idx->ne[0] * sizeof(int64_t));
+    this->gpu_neu_mask_vec.resize(ffn_gpu_neu_mask->ne[0], 0);
+    memcpy(gpu_neu_mask_vec.data(), ffn_gpu_neu_mask->data, ffn_gpu_neu_mask->ne[0] * sizeof(int64_t));
+
+    // 1.5 init group_to_neurons and neuron_to_group_map
+    // 1.5.1. get group_to_neurons_map
+    this->group_to_neurons_map_tensor = layer.ffn_group_to_neurons_map;
+    // 1.5.2. convert group_to_neurons_map_tensor to std::vector<std::vector<int64_t>>
+    // [YPX] [C] 我问过 AI，逐元素拷贝更快还是对每一个一维 vector 作 memcpy 更快，它说编译优化使两种方案的差距可以忽略不计
+    this->group_to_neurons_map.resize(layer_group_count);
+    for(int64_t i=0; i<layer_group_count; i++){
+        this->group_to_neurons_map[i].resize(layer_group_size);
+        for(int64_t j=0; j<layer_group_size; j++){
+            int64_t neuron_idx = ((int64_t *)group_to_neurons_map_tensor->data)[i * layer_group_size + j];
+            this->group_to_neurons_map[i][j] = neuron_idx;
+        }
+    }
+    // 1.5.3. get neuron_to_group_map_tensor
+    // Note: this tensor is only used in the constructor, so we don't need to store it as a member variable
+    ggml_tensor * neuron_to_group_map_tensor   = layer.ffn_neuron_to_group_map; 
+    // 1.5.4. convert neuron_to_group_map_tensor to std::vector<int64_t>
+    this->neuron_to_group_map.resize(neuron_to_group_map_tensor->ne[0], -1);
+    memcpy(neuron_to_group_map.data(), neuron_to_group_map_tensor->data, neuron_to_group_map_tensor->ne[0] * sizeof(int64_t));
+
+    // 1.6 init activated_group_mask
+    this->activated_group_mask.resize(layer_group_capacity);
+
+    // 1.7 init dfr related data structures but don't fill them
+    this->dfr_bonus = dfr_bonus;
+    this->dfr_decay = dfr_decay;
+    this->group_dfr_tracker.resize(layer_group_count, 0);
+
+    // 1.8 init slots related data structures but don't fill them
+    this->group_to_slot_map.resize(layer_group_count, -1);
+    this->slot_to_group_map.resize(layer_group_capacity, -1);
+
+    // ====================================================
+    // 2. fill dfr related and slots related data structures
+    // ====================================================
+
+    // 2.1 convert ffn_gpu_neu_idx to a vector named "sparse_idx", to cheat the functions below
+    std::vector<int64_t> sparse_idx;
+    for(int64_t i=0; i<ffn_gpu_neu_idx->ne[0]; i++){
+        sparse_idx.push_back(((int64_t *)ffn_gpu_neu_idx->data)[i]);
+    }
+
+    // 2.2 call utility functions
+    if(update_activated_group_mask(sparse_idx) && update_DFR() && update_slots()){
+        LLAMA_LOG_DEBUG("%s: Layer cache for layer %d initialized successfully.\n");
+    } else{
+        LLAMA_LOG_DEBUG("[Error] %s: Failed to initialize layer cache for layer %d.\n");
+    }
+
+}
+
+sparkinfer_reload_plan layer_cache::plan_reload(ggml_tensor * sparse_idx_tensor){
+
+    // 1. convert sparse_idx_tensor to a vector named "sparse_idx"
+    std::vector<int64_t> sparse_idx;
+    for(int64_t i=0; i<sparse_idx_tensor->ne[0]; i++){
+        sparse_idx.push_back(((int64_t *)sparse_idx_tensor->data)[i]);
+    }
+
+    // 2. call utility functions
+    update_activated_group_mask(sparse_idx);
+    update_DFR();
+    update_slots();
+    update_idx_and_mask();
+    return generate_reload_plan();
+
+}
+
+bool layer_cache::update_activated_group_mask(const std::vector<int64_t>& sparse_idx) {
+
+    // 1. reset activated_group_mask to all 0
+    std::fill(activated_group_mask.begin(), activated_group_mask.end(), 0);
+
+    // 2. Use vector to count activated neurons per group
+    std::vector<int64_t> group_activation_counts(layer_group_count, 0);
+    for (int64_t neuron_idx : sparse_idx) {
+        int64_t group_idx = neuron_to_group_map[neuron_idx];
+        if (group_idx >= 0 && group_idx < layer_group_count) { // Security check
+            group_activation_counts[group_idx]++;
+        }
+    }
+
+    // 3. convert the result int64_to <count, group_id> for quick sorting
+    std::vector<std::pair<int64_t, int64_t>> top_k_candidates;
+    top_k_candidates.reserve(layer_group_count);
+    for (int64_t i = 0; i < layer_group_count; ++i) {
+        if (group_activation_counts[i] > 0) { // only consider groups that has at least one activated neuron
+            top_k_candidates.push_back({group_activation_counts[i], i});
+        }
+    }
+
+    // 4. use std::partial_sort to find top-k groups
+    const int64_t k = std::min(layer_group_capacity, (int64_t)top_k_candidates.size()); // ensure k doesn't exceed the count of candidates
+    std::partial_sort(
+        top_k_candidates.begin(),
+        top_k_candidates.begin() + k,
+        top_k_candidates.end(),
+        [](const auto& a, const auto& b) {
+            return a.first > b.first; // descend by activated neurons count
+        }
+    );
+
+    // 5. update activated_group_mask
+    for (int64_t i = 0; i < k; ++i) {
+        int64_t group_idx = top_k_candidates[i].second; // .second is group_idx
+        activated_group_mask[group_idx] = 1;
+    }
+
+    return true;
+
+}
+
+bool layer_cache::update_DFR(){
+
+    // 1. iterate through activated_group_mask, and update group_dfr_tracker
+    //      DFR equation:
+    //      if activated (mask == 1): new_value = current_value * decay_rate + bonus; 
+    //      else (mask == 0)        : new_value = current_value * decay_rate
+    for(int64_t i=0; i<layer_group_count; i++){
+        group_dfr_tracker[i] = group_dfr_tracker[i] * dfr_decay + activated_group_mask[i] * dfr_bonus;
+    }
+
+    // 2. clear group_dfr_heap, and push all groups int64_to it
+    while(!group_dfr_heap.empty()){
+        group_dfr_heap.pop();
+    }
+    for(int64_t i=0; i<layer_group_count; i++){
+        group_dfr_heap.push(DFR_Node(i, group_dfr_tracker[i]));
+    }
+    return true;
+
+}
+
+bool layer_cache::update_slots(){
+
+    // 1. compute groups_to_reload according to activated_group_mask and group_to_slot_map(to make sure whether a group is already in a slot)
+    groups_to_reload.clear();
+    for(int64_t i=0; i<layer_group_count; i++){
+        if(activated_group_mask[i] == 1 && group_to_slot_map[i] == -1){
+            groups_to_reload.push_back(i);
+        }
+    }
+
+    // 2. compute slots_for_reload according to the size of groups_to_reload, select the k-th smallest dfr score groups to evict, and find their corresponding slots idx
+    slots_for_reload.clear();
+    int64_t k = groups_to_reload.size();
+    if(k == 0) return true;
+
+    std::vector<int64_t> groups_to_evict;
+    groups_to_evict.reserve(k); // pre-allocate to boost efficiency
+
+    // We need to evict some groups && their are still enought slots for eviction
+    while (groups_to_evict.size() < k && !group_dfr_heap.empty()) {
+        DFR_Node top = group_dfr_heap.top();
+        group_dfr_heap.pop();
+
+        // Only when this group is currently on gpu can you evict it.
+        if (group_to_slot_map[top.second] != -1) {
+            groups_to_evict.push_back(top.second);
+        }
+    }
+
+    // Security check: if there isn't enough slots to be evicted, show error.
+    if (groups_to_evict.size() < k) {
+        LLAMA_LOG_ERROR("%s: could not find enough slots to evict\n", __func__);
+        return false;
+    }
+
+    // 3. update group_to_slot_map and slot_to_group_map according to groups_to_reload and slots_for_reload (make sure the mapping is one-to-one)
+    for(int64_t i=0; i<k; i++){
+        int64_t group_idx = groups_to_reload[i];
+        int64_t evict_group_idx = groups_to_evict[i];
+        int64_t slot_idx = group_to_slot_map[evict_group_idx];
+
+        // update group_to_slot_map
+        group_to_slot_map[group_idx] = slot_idx;
+        group_to_slot_map[evict_group_idx] = -1;
+
+        // update slot_to_group_map
+        slot_to_group_map[slot_idx] = group_idx;
+    }
+    return true;
+}
+
+bool layer_cache::update_idx_and_mask(){
+
+    // ====================================================
+    // 1. update gpu_neu_idx/mask_vec according to group_to_slot_map, slot_to_group_map and group_to_neurons_map
+    // ====================================================
+
+    // 1.1 update gpu_neu_idx_vec
+    gpu_neu_idx_vec.clear();
+    for(int64_t slot_idx=0; slot_idx<layer_group_capacity; slot_idx++){
+        int64_t group_idx = slot_to_group_map[slot_idx];
+        if(group_idx != -1){
+            for(int64_t j=0; j<layer_group_size; j++){
+                int64_t neuron_idx = group_to_neurons_map[group_idx][j];
+                gpu_neu_idx_vec.push_back(neuron_idx);
+            }
+        }
+    }
+
+    // 1.2 update gpu_neu_mask_vec
+    std::fill(gpu_neu_mask_vec.begin(), gpu_neu_mask_vec.end(), 0);
+    for(int64_t slot_idx=0; slot_idx<layer_group_capacity; slot_idx++){
+        int64_t group_idx = slot_to_group_map[slot_idx];
+        if(group_idx != -1){
+            for(int64_t j=0; j<layer_group_size; j++){
+                int64_t neuron_idx = group_to_neurons_map[group_idx][j];
+                gpu_neu_mask_vec[neuron_idx] = 1;
+            }
+        }
+    }
+
+    // ====================================================
+    // 2. copy gpu_neu_idx/mask_vec back to ffn_gpu_neu_idx/mask
+    // ====================================================
+    memcpy(ffn_gpu_neu_idx->data, gpu_neu_idx_vec.data(), gpu_neu_idx_vec.size() * sizeof(int64_t));
+    memcpy(ffn_gpu_neu_mask->data, gpu_neu_mask_vec.data(), gpu_neu_mask_vec.size() * sizeof(int64_t));
+    return true;
+
+}
+
+sparkinfer_reload_plan layer_cache::generate_reload_plan(){
+    return sparkinfer_reload_plan(groups_to_reload, slots_for_reload, gpu_neu_idx_vec, gpu_neu_mask_vec);
+}
+
+sparkinfer_cache_manager::sparkinfer_cache_manager(const llama_model & model, const llama_cparams & params){
+    n_layer = model.hparams.n_layer;
+    for(int64_t i=0; i<n_layer; i++){
+        layer_caches.push_back(new layer_cache(model.layers[i], i, dfr_decay, dfr_bonus));
+    }
+}

--- a/src/llama-sparkinfer.h
+++ b/src/llama-sparkinfer.h
@@ -1,22 +1,57 @@
 #pragma once
 
 #include "llama.h"
+#include "llama-impl.h"
 #include "llama-memory.h"
-
+#include "llama-context.h"
+#include "llama-model.h"
 #include "ggml-cpp.h"
 
 #include <vector>
+#include <queue>
+#include <unordered_map>
+#include <deque>
+#include <functional>
+#include <cstring> // for memcpy
+#include <utility> // for std::pair
+#include <cstdint>
+#include <ggml-cuda.h>
 
+// Using forward declaration, rather than including the whole head file, is recommended when you use only the pointers of these classed instead of their instances.
 struct llama_cparams;
 struct llama_model;
 struct llama_context;
 
-#include <vector>
+struct sparkinfer_reload_plan {
+    std::vector<int64_t> groups_to_reload;
+    std::vector<int64_t> slots_for_reload;
+    std::vector<int64_t> new_gpu_neu_idx_vec;
+    std::vector<int64_t> new_gpu_neu_mask_vec;
+
+    // [YPX] [C] 我决定不用 ggml_tensor *，还是用 vector；到最后传入 GGML_OP_RELOAD 的时候再搞成 ggml_tensor *
+    // ggml_tensor * new_gpu_neu_idx_cpu;
+    // ggml_tensor * new_gpu_neu_mask_cpu;
+
+    // Constructor
+    sparkinfer_reload_plan(
+        const std::vector<int64_t>& reload_groups,
+        const std::vector<int64_t>& reload_slots,
+        const std::vector<int64_t>& new_neu_idx,
+        const std::vector<int64_t>& new_neu_mask):  
+        groups_to_reload(reload_groups),
+        slots_for_reload(reload_slots),
+        new_gpu_neu_idx_vec(new_neu_idx),
+        new_gpu_neu_mask_vec(new_neu_mask){};
+};
 
 struct layer_cache{
-    layer_cache();
+
+public:
+
+    layer_cache(const llama_layer & layer, int64_t layer_idx, double dfr_decay, double dfr_bonus);
     ~layer_cache() = default;
 
+    /* [YPX] [C] cache_manager 和 layer_cache 根本不管理这些变量，不需要也不应该在这里保存
     ggml_tensor * get_cpu_gate(ggml_context * ctx);
     ggml_tensor * get_cpu_up(ggml_context * ctx);
     ggml_tensor * get_cpu_down_t(ggml_context * ctx);
@@ -27,33 +62,83 @@ struct layer_cache{
 
     ggml_tensor * get_gpu_neu_idx(ggml_context * ctx);
     ggml_tensor * get_gpu_neu_mask(ggml_context * ctx);
-    ggml_tensor * get_DFR(ggml_context * ctx);
 
     ggml_tensor * reload_gate(ggml_context * ctx);
     ggml_tensor * reload_up(ggml_context * ctx);
     ggml_tensor * reload_down_t(ggml_context * ctx);
+    */
+
+    ggml_tensor * get_group_to_neurons_map(ggml_context);
+
+    sparkinfer_reload_plan plan_reload(ggml_tensor * sparse_idx);
 
 private:
 
-    int     layer_idx                               = -1;
-    bool    full_gpu                                = false;
+    int64_t layer_idx   = -1;
+    bool  full_gpu    = false;
 
+    /* [YPX] [C] 同上，这些变量没有必要了，因为 cache_manager 和 layer_cache 只负责给出 reload 方案，而不负责具体的 reload 行为
     // full ffn weights and biases on cpu
-    ggml_tensor * cpu_ffn_gate                = nullptr;
-    ggml_tensor * cpu_ffn_up                  = nullptr;
-    ggml_tensor * cpu_ffn_down_t              = nullptr;
+    ggml_tensor * cpu_ffn_gate                  = nullptr;
+    ggml_tensor * cpu_ffn_up                    = nullptr;
+    ggml_tensor * cpu_ffn_down_t                = nullptr;
+    ggml_tensor * cpu_ffn_gate_b                = nullptr;
+    ggml_tensor * cpu_ffn_up_b                  = nullptr;
+    ggml_tensor * cpu_ffn_down_b                = nullptr;
 
     // cached ffn weights and biases on gpu
-    ggml_tensor * gpu_ffn_gate                = nullptr;
-    ggml_tensor * gpu_ffn_up                  = nullptr;
-    ggml_tensor * gpu_ffn_down_t              = nullptr;
+    ggml_tensor * gpu_ffn_gate                  = nullptr;
+    ggml_tensor * gpu_ffn_up                    = nullptr;
+    ggml_tensor * gpu_ffn_down_t                = nullptr;
+    ggml_tensor * gpu_ffn_gate_b                = nullptr;
+    ggml_tensor * gpu_ffn_up_b                  = nullptr;
+    ggml_tensor * gpu_ffn_down_b                = nullptr;
+    */
 
     ggml_tensor * ffn_gpu_neu_idx             = nullptr;
     ggml_tensor * ffn_gpu_neu_mask            = nullptr;
 
-    // DFR Related
-    const double dfr_decay              = 0.95;
-    ggml_tensor * DFR                    = nullptr;
+    std::vector<int64_t> gpu_neu_idx_vec;
+    std::vector<int64_t> gpu_neu_mask_vec;
+
+    int64_t layer_neuron_count;     // number of neurons in the layer
+    int64_t layer_group_count;      // number of groups in the layer
+    int64_t layer_group_size;       // number of neurons in each group
+    int64_t layer_neuron_capacity;  // number of neurons that can be cached on GPU
+    int64_t layer_group_capacity;   // number of groups that can be cached on GPU
+
+    // groups and neurons mapping structures
+    ggml_tensor * group_to_neurons_map_tensor      = nullptr; // not used in layer_cache but stored here, only used by GGML_OP_RELOAD node for doing memcpy.
+    std::vector<std::vector<int64_t>> group_to_neurons_map; // used in update_idx_and_mask()
+    std::vector<int64_t> neuron_to_group_map; // used in update_activated_group_mask()
+
+    // activated group mask, used only inside layer_cache
+    std::vector<int64_t> activated_group_mask;
+
+    // DFR related structures
+    double dfr_decay = 0.75;
+    double dfr_bonus = 1.00;
+
+    std::vector<double> group_dfr_tracker;
+
+    // [YPX] [Q] 这么写可以吗？
+    using DFR_Node = std::pair<double, int64_t>;
+
+    std::priority_queue<DFR_Node, std::vector<DFR_Node>, std::greater<DFR_Node>> group_dfr_heap;
+
+    // slots related structures
+    std::vector<int64_t>        group_to_slot_map;
+    std::vector<int64_t>        slot_to_group_map;
+    std::vector<int64_t>        groups_to_reload;
+    std::vector<int64_t>        slots_for_reload;
+
+    // utility functions for generating reload plan
+    bool update_activated_group_mask(const std::vector<int64_t>& sparse_idx);
+    bool update_DFR();
+    bool update_slots();
+    bool update_idx_and_mask();
+    sparkinfer_reload_plan generate_reload_plan();
+    
 };
 
 
@@ -61,20 +146,21 @@ struct sparkinfer_cache_manager: public llama_memory_i{
     sparkinfer_cache_manager(const llama_model & model, const llama_cparams & cparams);
     ~sparkinfer_cache_manager() = default;
 
+    // [YPX] [C] 这些函数直接设置为默认实现，因为因为不需要用到它们
     // override the function in llama-memory-i
-    void clear() override;
-    bool seq_rm  (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1) override;
-    void seq_cp  (llama_seq_id seq_id_src, llama_seq_id seq_id_dst, llama_pos p0, llama_pos p1) override;
-    void seq_keep(llama_seq_id seq_id)                                                          override;
-    void seq_add (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1, llama_pos shift) override;
-    void seq_div (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1, int d) override;
+    void clear() override {}
+    bool seq_rm  (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1) override { return true; }
+    void seq_cp  (llama_seq_id seq_id_src, llama_seq_id seq_id_dst, llama_pos p0, llama_pos p1) override {}
+    void seq_keep(llama_seq_id seq_id)                                                          override {}
+    void seq_add (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1, llama_pos shift) override {}
+    void seq_div (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1, int64_t d) override {}
     
-    llama_pos seq_pos_min(llama_seq_id seq_id) const override;
-    llama_pos seq_pos_max(llama_seq_id seq_id) const override;
+    llama_pos seq_pos_min(llama_seq_id seq_id) const override { return 0; }
+    llama_pos seq_pos_max(llama_seq_id seq_id) const override { return 0; }
    
-    bool get_can_edit() const override;
+    bool get_can_edit() const override { return false; }
 
-    layer_cache * get_layer_cache(int layer_idx) const{
+    layer_cache * get_layer_cache(int64_t layer_idx) const{
         if(layer_idx < 0 || layer_idx >= n_layer){
             return nullptr;
         }
@@ -83,5 +169,7 @@ struct sparkinfer_cache_manager: public llama_memory_i{
 
 private:
     int64_t n_layer = 0;
+    double dfr_decay = 0.75;
+    double dfr_bonus = 1.00;
     std::vector<layer_cache*> layer_caches;
 };


### PR DESCRIPTION
`sparkinfer_cache_manager` and `layer_cache` have already finished.
Add a new class named `sparkinfer_reload_plan`, which is return by `layer_cache.plan_reload()` to conduct the reload process.
To Do List:
- [ ] `build_sparse_reload_group()` in `llama-graph.cpp`
- [ ] `GGML_OP_RELOAD` and its `compute_forward()`
- [ ] modify `sparkinfer-py/src/sparkinfer/export_split.py` to store `layer_group_size`(exist in `.py` file but not in `.gguf` file), `group_to_neuron_map`(exist in `.py` file but not in `.gguf` file) and `neuron_to_group_map`(already in `.gguf` file) into `.gguf` file, since the neuron weights in our .`gguf` file are still not organized in groups.