### PR TITLE
Refactor: Move reload plan logic into `sparkInfer_layer_cache`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *.so
 *.swp
 *.tmp
+*.bak
 
 # IDE / OS
 

--- a/ggml/include/ggml-spif.h
+++ b/ggml/include/ggml-spif.h
@@ -4,14 +4,11 @@
 #include "ggml.h" 
 
 struct reload_plan_result {
-    int * slot_to_evict;
-    int * slot_to_load;
-    size_t n_reload;
-
-    reload_plan_result() : slot_to_evict(nullptr), slot_to_load(nullptr), n_reload(0) {}
+    std::vector<int> groups_to_reload;
+    std::vector<int> slots_for_evict;
 };
 typedef struct reload_plan_result reload_plan_result;
-  
+
 #ifdef __cplusplus  
 extern "C" {  
 #endif  

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -63,6 +63,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include <queue>
 
 #define USE_NVTX 0
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -63,7 +63,6 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
-#include <queue>
 
 #define USE_NVTX 0
 

--- a/notes/reload-design.md
+++ b/notes/reload-design.md
@@ -1,0 +1,59 @@
+# Reload 设计文档
+
+## 1. reload_plan 潜在的更高效实现——使用集合差集
+
+### 函数功能转移
+
+- 现在按照甘明昊的思路，由于 `op_params` 的强大特性，我们可以在算子函数里面调用上层类 `sparkinfer_cache_manage` 的成员函数。于是乎，我们决定把产生 `sparkinfer_reload_plan` 的逻辑（算子一、二的逻辑）转移到 `sparkinfer_cache_manager::spif_reload_plan()` 里面实现。
+
+### 术语澄清
+
+- 原本的算子一要产生的是 `groups_to_load`（真正要进行传输的组）而不是 `groups_to_reload`（应该在 GPU 上的组）。我认为，我应该把后面那个变量的名字改为 `groups_to_ensure`，表示应该在 GPU 上的组，用 `groups_to_reload` 表示应该在 GPU 上但实际上不在，需要被 reload 的组。我们用 `N` 表示 `layer_group_count`，用 `k` 表示 `layer_group_capacity`。
+
+### `spif_cache` 和 算子函数 的交互方式
+
+- 把 `groups_to_reload` 和 `slots_to_evict` 作为 `sparkInfer_layer_cahce` 的成员变量
+- 把 `sparse_idx` 作为 `sparkInfer_layer_cahce` 的成员 `tensor`
+- 每次进行 reload 时：
+    - 算子函数执行拷贝，把 `sparse_idx` 从 GPU 拷贝下来，拷贝到 `spif_cache` 的那个 `ggml_tensor * sparse_idx` 中
+    - 算子函数调用 `spif_cache->spif_reload_plan()`，返回一个 `reload_plan_result`
+    - 算子函数访问 `spif_cache->spif_layer[li]->groups_to_reload`，以及 `slots_to_evict`，并直接 for 循环遍历它们，执行拷贝
+
+`reload_plan_result` 的定义如下：
+
+```cpp
+// ggml-spif.h
+struct reload_plan_result {
+    std::vector<int> groups_to_reload;
+    std::vector<int> slots_for_evict;
+};
+typedef struct reload_plan_result reload_plan_result;
+```
+
+### 管理类 `spif_cache` 的设计思路
+
+成员变量：
+
+- `std::vector<int> dfr_score(layer_group_count)`
+- `ggml_tensor * sparse_idx`
+- `std::vector<int> groups_to_reload`
+- `std::vector<int> slots_for_reload`
+- `float dfr_decay_rate`
+- `std::unorderd_map<int, int> group_to_slot_hash`
+- 其他指向 gpu weights cache 和 cpu weights cache 的 ggml_tensor 指针
+
+### 成员函数 `spif_reload_plan()`
+
+- **使用哪一种 Reload 策略**：可以在 [llama-sparkinfer.h](../src/llaam-sparkinfer.h)里面通过宏来设置。
+
+核心逻辑：
+
+1. 第一步：执行 `spif_reload_plan_count_activated_neurons()`，得到 `group_activated_neurons_count` 数组
+    - 算法：遍历所有组和所有神经元，时间复杂度为 $O(N + k) \approx O(N)$
+2. 第二步：执行 `spif_reload_plan_get_groups_to_ensure()` 函数，该函数调用 `spif_reload_plan_use_dfr()` 等等策略函数，得到 `groups_to_ensure` 数组
+    - 算法：小根堆，每次排序的时候重建，时间复杂度为 $O(N \log k)$
+3. 第三步：执行 `spif_reload_plan_get_groups_to_reload()` 和 `spif_reload_plan_get_slot_to_evict()`，根据 `groups_to_ensure` 数组和 `slot_to_group_map`，算出 `groups_to_reload` 和 `slot_to_evict`
+    - 算法：新的思路，也就是直接把 `slot_to_group_map` 删除，把 `group_to_slot_map` 改为 `group_to_slot_hash`，首先把 `groups_to_ensure` 转换为 set，再和 `group_to_slot_hash` 的所有 key 组成的集合进行集合差集运算，然后对于差集出来的两个集合 `groups_to_reload` 和 `groups_to_evict`，我们遍历 `groups_to_evict`，在 `group_to_slot_hash` 里面查找其 slot 编号；时间复杂度为建立 `groups_to_ensure` 的 set 的时间复杂度 $O(k)$ + 获取 `group_to_slot_hash` 的所有 key 组成 set $O(k)$ + 差集运算的时间复杂度 $O(k)$ + 查找的总时间复杂度 $O(k)$ = $O(k)$
+4. 第四步：执行 `spif_reload_plan_update_mappings()` 函数，如果上一步选择算法一，就更新 `slot_to_group_map` 和 `group_to_slot_map`，如果上一步选择算法二，就更新 `group_to_slot_hash`。
+
+## 2. Reload 算子设计——如何执行异步拷贝？

--- a/notes/reload_operand_design.md
+++ b/notes/reload_operand_design.md
@@ -1,5 +1,7 @@
 # Reload 算子设计
 
+> 本文已经过时，最新的算子设计请移步 [reload 设计文档](reload-design.md)
+
 > 关于 sparkinfer_cache_manager 的设计思路，请移步 [sparkinfer_cache_manager 设计文档](sparkinfer_cache_manager_design.md)
 
 YPX 的个人注释风格解释：

--- a/notes/reload_strategy_design.md
+++ b/notes/reload_strategy_design.md
@@ -8,7 +8,7 @@
 
 - 修改 `GGML_MAX_SRC = 20`，合并为一个算子，但是仍然调用三个函数：
 
-1. `sparkinfer_reload_plan()` <-- Reload 策略变更时，只有这个函数需要被修改！
+1. `sparkinfer_reload_plan()` **<-- Reload 策略变更时，只有这个函数需要被修改！**
 2. `sparkinfer_reload_evict()`
 3. `sparkinfer_reload_exec()`
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -261,6 +261,8 @@ llama_context::llama_context(
     }
 
     if (!hparams.vocab_only && llama_use_sparkinfer(&model)) {
+        // [YPX] [Q] 为什么 spif_cache 存储在 model 里面？
+        // [YPX] [Todo] 这里要引用 sparkInfer_cache_manager 的初始化逻辑。
         spif_cache = model.spif_cache; // GTODO: use unique_ptr??
     }
 

--- a/src/llama-sparkinfer.cpp
+++ b/src/llama-sparkinfer.cpp
@@ -9,253 +9,167 @@ sparkInfer_layer_cache::~sparkInfer_layer_cache() {
     }
 }
 
-bool sparkInfer_layer_cache:: init(int layer_idx, llama_model& model, llama_layer& layer, ggml_backend_t backend, const std::vector<int64_t>& initial_gpu_neu_idx) {
-    bool has_gate = true; // GTODO: gate diverage
-    bool full_gpu = layer.gpu_offload_ratio >= 1;
+// [YPX] [C] Init function is replaced by the constructor, which has not been merged yet.
 
-    // init backend
-    gpu_backend             = backend;
-    cpu_backend             = ggml_backend_cpu_init();
+// Sparkinfer reload (graph building)
+ggml_tensor * sparkInfer_layer_cache::build_reload_plan(ggml_context * ctx, ggml_tensor * sparse_idx, const int il){
+    // [YPX] [Todo] Implementation
+    return nullptr;
+}
 
-    // cpu side tensors
-    cpu_ffn_gate            = has_gate ? layer.ffn_gate : nullptr;
-    cpu_ffn_up              = layer.ffn_up;
-    cpu_ffn_down_t          = layer.ffn_down_t;
+ggml_tensor * sparkInfer_layer_cache::build_reload_exec(ggml_context * ctx, ggml_tensor * sparse_idx, const char * name, const int il){
+    // [YPX] [Todo] Implementation
+    return nullptr;
+}
 
-    // mappings
-    ffn_gpu_neu_idx         = layer.ffn_gpu_neu_idx;
-    ffn_gpu_neu_mask        = layer.ffn_gpu_neu_mask;
-    ffn_gpu_group_idx       = layer.ffn_gpu_group_idx;
-    ffn_gpu_group_mask      = layer.ffn_gpu_group_mask;
-    ffn_neuron_to_group_map = layer.ffn_neuron_to_group_map;
-    
-    // metadata
-    layer_neuron_count      = model.layer_neuron_count; // 每层神经元总数
-    layer_group_size        = model.layer_group_size; // 每层分组大小
-    layer_group_count       = model.layer_group_count; // 每层分组数量
-    neuron_cache_capacity   = initial_gpu_neu_idx.size();
-    if (neuron_cache_capacity == 0) return true; // 无需卸载
-
-    // init DRF_score from ffn_gpu_neu_mask, simply cpy the mask to score with int64_t to float conversion
-    // maybe we coulf optimize this later
-    if(!full_gpu){
-        struct ggml_init_params params = { ggml_tensor_overhead() * 2, NULL, true };
-        tmp_ctx = ggml_init(params);
-        dfr_score = ggml_new_tensor_1d(tmp_ctx, GGML_TYPE_F32, ffn_gpu_neu_mask->ne[0]);
-        ggml_set_name(dfr_score, (std::string("blk.") + std::to_string(layer_idx) + std::string(".ffn_dfr_score")).c_str());
-
-        // alloc buffer for dfr_score
-        ggml_backend_buffer_t dfr_score_buffer = ggml_backend_alloc_buffer(cpu_backend, ggml_nbytes(dfr_score));
-        if (!dfr_score_buffer) {
-            LLAMA_LOG_ERROR("%s: failed to allocate CPU buffer for dfr_score\n", __func__);
-            return false;
-        }
-        ggml_backend_tensor_alloc(dfr_score_buffer, dfr_score, ggml_backend_buffer_get_base(dfr_score_buffer));
-
-        const int64_t n_mask = ffn_gpu_neu_mask->ne[0];
-        int64_t * mask_data = (int64_t*)ffn_gpu_neu_mask->data;
-        float * score_data = new float[ffn_gpu_neu_mask->ne[0]];
-        for(int64_t i=0; i<n_mask; i++){
-            score_data[i] = (float)(mask_data[i]);
-        }
-        ggml_backend_tensor_set(dfr_score, score_data, 0, ggml_nbytes(dfr_score));  // if we could get buffer from score directly, we could optimize this by direct cpy
-        delete[] score_data;
-    }
-
-    /* debug info */ 
-    // FILE* log_file = fopen("debug_split_info.log", "a");
-    // if (log_file == NULL) {
-    //     // 如果文件打开失败，可以打印一个错误到 stderr 然后继续，或者直接退出
-    //     perror("Failed to open log file");
-    //     // return; // 或者根据你的错误处理逻辑决定是否返回
-    // }
-    // std::time_t result = std::time(nullptr);
-    // fprintf(log_file, "\n--- Debugging Layer %d split info into file, timestamp %s ---", layer_idx, std::ctime(&result)); // 添加一些上下文信息
-    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_neu_idx);
-    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_neu_mask);
-    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_group_idx);
-    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_group_mask);
-    // debug_print_tensor_i64_to_file(log_file, ffn_neuron_to_group_map);
-    // fflush(log_file);
-    // fclose(log_file);
-    /* debug info end */ 
-
-    GGML_ASSERT(neuron_cache_capacity <= layer_neuron_count && "we required neuron_cache_capacity <= layer_neuron_count");
-
-    // 1. 计算并分配ffn buffer size
-    const size_t single_mat_size = ggml_backend_buft_get_alloc_size(
-        ggml_backend_get_default_buffer_type(gpu_backend),
-        cpu_ffn_down_t // 使用其中一个矩阵作为尺寸参考
-    );
-    // 我们只缓存部分行，所以要按比例计算
-    const size_t single_cache_size = (single_mat_size / layer_neuron_count) * neuron_cache_capacity;
-    
-    // 总大小 = 3个矩阵的缓存大小之和
-    const size_t total_gpu_buffer_size = single_cache_size * 3;
-
-    gpu_weights_buffer = ggml_backend_alloc_buffer(gpu_backend, total_gpu_buffer_size);
-    if (!gpu_weights_buffer) {
-        LLAMA_LOG_ERROR("%s: failed to allocate GPU buffer for layer cache\n", __func__);
-        return false;
-    }
-
-    // 2. 在GPU缓存池中创建代表缓存张量
-    struct ggml_init_params params = { ggml_tensor_overhead() * 6, NULL, true };
-    tmp_ctx = ggml_init(params);
-
-    void* current_addr = ggml_backend_buffer_get_base(gpu_weights_buffer);
-    
-    char gate_name[64];
-
-    if(has_gate) {
-        gpu_ffn_gate_cache = ggml_new_tensor_2d(tmp_ctx, cpu_ffn_gate->type, cpu_ffn_gate->ne[0], neuron_cache_capacity);
-        snprintf(gate_name, sizeof(gate_name), "blk.%d.ffn_gpu_gate.weight", layer_idx);
-        ggml_set_name(gpu_ffn_gate_cache, gate_name);
-        ggml_backend_tensor_alloc(gpu_weights_buffer, gpu_ffn_gate_cache, current_addr);
-        current_addr = (char*)current_addr + single_cache_size;
-    }
-
-    gpu_ffn_up_cache = ggml_new_tensor_2d(tmp_ctx, cpu_ffn_up->type, cpu_ffn_up->ne[0], neuron_cache_capacity);
-    snprintf(gate_name, sizeof(gate_name), "blk.%d.ffn_gpu_up.weight", layer_idx);
-    ggml_set_name(gpu_ffn_up_cache, gate_name);
-    ggml_backend_tensor_alloc(gpu_weights_buffer, gpu_ffn_up_cache, current_addr);
-    current_addr = (char*)current_addr + single_cache_size;
-
-    gpu_ffn_down_t_cache = ggml_new_tensor_2d(tmp_ctx, cpu_ffn_down_t->type, cpu_ffn_down_t->ne[0], neuron_cache_capacity);
-    snprintf(gate_name, sizeof(gate_name), "blk.%d.ffn_gpu_down_t.weight", layer_idx);
-    ggml_set_name(gpu_ffn_down_t_cache, gate_name);
-    ggml_backend_tensor_alloc(gpu_weights_buffer, gpu_ffn_down_t_cache, current_addr);
-    
-    // 将新的GPU缓存张量赋给llama_layer
-    layer.ffn_gpu_gate = has_gate ? gpu_ffn_gate_cache : nullptr;
-    layer.ffn_gpu_up   = gpu_ffn_up_cache;
-    layer.ffn_gpu_down_t = gpu_ffn_down_t_cache;
-
-    // 3. init slot_to_neuron_map from ffn_gpu_neu_idx, and copy data to buffer
-    auto t_start = ggml_time_ms();
-    slot_to_neuron_map.resize(neuron_cache_capacity, -1);
-
-    auto batch_copy_neurons = [&](ggml_tensor* cpu_src, ggml_tensor* gpu_dst_cache, const std::vector<int64_t>& indices, const bool full_gpu) {
-        if(full_gpu){
-            const size_t full_tensor_bytes = ggml_nbytes(cpu_src);
-            ggml_backend_tensor_set(gpu_dst_cache, cpu_src->data, 0, full_tensor_bytes);
-        }else{
-            const int64_t n_embd = cpu_src->ne[0];
-            const size_t row_size_bytes = ggml_row_size(cpu_src->type, n_embd);
-            
-            // 在CPU上分配一个临时暂存缓冲区
-            std::vector<char> staging_buffer(row_size_bytes * indices.size());
-            
-            for (size_t i = 0; i < indices.size(); ++i) {
-                const int64_t neuron_idx = indices[i];
-                
-                // 源地址：在完整CPU张量中的位置
-                char* src_ptr = (char*)cpu_src->data + neuron_idx * cpu_src->nb[1];
-                
-                // 目标地址：在暂存缓冲区中的位置
-                char* dst_ptr = staging_buffer.data() + i * row_size_bytes;
-                
-                memcpy(dst_ptr, src_ptr, row_size_bytes);
-            }
-            
-            ggml_backend_tensor_set(gpu_dst_cache, staging_buffer.data(), 0, staging_buffer.size());
-        }
-    };
-
-    if(has_gate) batch_copy_neurons(cpu_ffn_gate, gpu_ffn_gate_cache, initial_gpu_neu_idx, full_gpu);
-    batch_copy_neurons(cpu_ffn_up, gpu_ffn_up_cache, initial_gpu_neu_idx, full_gpu);
-    batch_copy_neurons(cpu_ffn_down_t, gpu_ffn_down_t_cache, initial_gpu_neu_idx, full_gpu);
-
-    // 更新元数据
-    offloaded_bytes += ggml_nbytes(gpu_ffn_up_cache) * (has_gate ? 3 : 2); // 每个神经元有3个矩阵
-    for (size_t i = 0; i < initial_gpu_neu_idx.size(); ++i) {
-        int64_t neuron_idx = initial_gpu_neu_idx[i];
-        int64_t slot_idx = i;
-        update_mappings(neuron_idx, slot_idx);
-    }
-
-    auto t_end = ggml_time_ms();
-    LLAMA_LOG_INFO("%s: layer %d offload in %lld ms, cached %d neurons %s\n", __func__, layer_idx, t_end - t_start, neuron_cache_capacity, full_gpu?"(full_gpu)":" ");
-
+// [YPX] [Q] Maybe these two functions are already implemented with names given by me?
+bool sparkInfer_layer_cache::spif_reload_plan(ggml_tensor * tensor){
+    // [YPX] [Todo] Implementation
     return true;
 }
 
-int64_t sparkInfer_layer_cache:: ensure_neuron_on_gpu(int64_t neuron_idx) {
-    auto it = neuron_to_slot_map.find(neuron_idx);
-    if (it != neuron_to_slot_map.end()) {
-        // Cache Hit: 神经元已在GPU上，更新其为最近使用
-        int64_t slot_idx = it->second;
-        lru_tracker.erase(lru_map[neuron_idx]);
-        lru_tracker.push_front(neuron_idx);
-        lru_map[neuron_idx] = lru_tracker.begin();
-        return slot_idx;
-    }
+bool sparkInfer_layer_cache::spif_reload_exec(ggml_tensor * tensor){
+    // [YPX] [Todo] Implementation
+    return true;
+}
 
-    // Cache Miss: 需要换入
-    int64_t slot_to_use = -1;
-    if (neuron_to_slot_map.size() < neuron_cache_capacity) {
-        // 缓存未满，找到一个空槽位
-        for(int64_t i = 0; i < (int64_t)slot_to_neuron_map.size(); ++i) {
-            if (slot_to_neuron_map[i] == -1) {
-                slot_to_use = i;
-                break;
+// --- Reload Plan Implementation ---
+/**
+ * @brief [Plan Step 1] 统计激活的神经元数量。
+ * @return std::vector<int> group_activated_neuron_count 每个组激活的神经元数量。
+ */
+std::vector<int> sparkInfer_layer_cache::_spif_reload_plan_count_activated_neurons(){
+    std::vector<int> group_activated_neuron_count(this->layer_group_count, 0);
+    const int* p_sparse_idx = (const int*)this->sparse_idx->data;
+
+    for (int neuron_idx = 0; neuron_idx < this->layer_neuron_count; ++neuron_idx) {
+        if (p_sparse_idx[neuron_idx]) { // 1 = activated
+            int group_idx = neuron_idx / this->layer_group_size;
+            if (group_idx < this->layer_group_count) { // 安全检查
+                group_activated_neuron_count[group_idx]++;
             }
         }
+    }
+    return group_activated_neuron_count;
+}
+
+/**
+ * @brief [Plan Step 2] 根据 DFR (或 LRU 等) 策略，计算出应在 GPU 上的 Top-K 组。
+ * @param group_activated_neuron_count Step 1 的结果。
+ * @return std::vector<int> groups_to_ensure 应该确保在 GPU 上的组列表。
+ */
+std::vector<int> sparkInfer_layer_cache::_spif_reload_plan_get_groups_to_ensure(const std::vector<int>& group_activated_neuron_count){
+    // 使用 constexpr if 达到编译时分派
+    if constexpr (SPARKINFER_RELOAD_STRATEGY == sparkinfer_reload_strategy::USE_DFR) {
+        return _spif_reload_plan_use_dfr(group_activated_neuron_count);
+    } else if constexpr (SPARKINFER_RELOAD_STRATEGY == sparkinfer_reload_strategy::USE_LRU) {
+        // _spif_reload_plan_use_lru(group_activated_neuron_count); // 调用 LRU 实现
+        GGML_LOG_ERROR("%s: [Error] LRU strategy not implemented yet.\n", __func__); 
     } else {
-        // 缓存已满，根据LRU策略选择牺牲品
-        int64_t victim_neuron_idx = lru_tracker.back();
-        lru_tracker.pop_back();
+        GGML_LOG_WARN("%s: [Warning] Unknown Reload Strategy, fall back to DFR\n", __func__);
+        return _spif_reload_plan_use_dfr(group_activated_neuron_count); // 默认使用 DFR
+    }
+}
+
+/**
+ * @brief [Plan Step 2.1] DFR 策略的具体实现。
+ */
+std::vector<int> sparkInfer_layer_cache::_spif_reload_plan_use_dfr(const std::vector<int>& group_activated_neuron_count) {
+    typedef std::pair<float, int> ScoreGroupPair;
+    std::priority_queue<ScoreGroupPair, std::vector<ScoreGroupPair>, std::greater<ScoreGroupPair>> min_heap;
+
+    for (int group_id = 0; group_id < this->layer_group_count; ++group_id) {
+        //  dfr_score = dfr_score * decay + is_activated * (1 - decay)
+        float is_activated = (group_activated_neuron_count[group_id] > 0) ? 1.0f : 0.0f;
+        float old_score = this->dfr_scores[group_id];
+        float new_score = old_score * this->dfr_decay_rate + is_activated * (1.0f - this->dfr_decay_rate);
         
-        slot_to_use = neuron_to_slot_map[victim_neuron_idx];
-        
-        neuron_to_slot_map.erase(victim_neuron_idx);
-        lru_map.erase(victim_neuron_idx);
+        this->dfr_scores[group_id] = new_score; // 持久化更新 DFR 分数
+
+        // 维护 Top-K 最小堆
+        if (min_heap.size() < (size_t)this->layer_group_capacity) {
+            min_heap.push({new_score, group_id});
+        } else if (new_score > min_heap.top().first) {
+            min_heap.pop();
+            min_heap.push({new_score, group_id});
+        }
     }
 
-    GGML_ASSERT(slot_to_use != -1);
-
-    // 执行拷贝并将新神经元信息写入元数据
-    copy_neuron_to_gpu_slot(neuron_idx, slot_to_use);
-    update_mappings(neuron_idx, slot_to_use);
-    
-    return slot_to_use;
-}   
-
-void sparkInfer_layer_cache:: copy_neuron_to_gpu_slot(int64_t neuron_idx, int64_t slot_idx) {
-    // 创建一个临时的上下文用于视图操作
-    struct ggml_init_params params = { ggml_tensor_overhead() * 6, NULL, true };
-    struct ggml_context* view_ctx = ggml_init(params);
-
-
-    auto copy_row = [&](ggml_tensor* cpu_src, ggml_tensor* gpu_dst_cache) {
-        const int64_t row_len = cpu_src->ne[0];
-        const size_t  row_bytes = ggml_row_size(cpu_src->type, row_len);
-
-        // 创建指向CPU源矩阵中特定行的视图
-        struct ggml_tensor* src_view = ggml_view_1d(view_ctx, cpu_src, row_len, neuron_idx * cpu_src->nb[1]);
-        src_view->buffer = cpu_src->buffer;
-
-        // 创建指向GPU缓存中特定槽位的视图
-        struct ggml_tensor* dst_view = ggml_view_1d(view_ctx, gpu_dst_cache, row_len, slot_idx * gpu_dst_cache->nb[1]);
-        dst_view->buffer = gpu_dst_cache->buffer;
-
-        // 使用后端进行异步拷贝
-        ggml_backend_tensor_copy(src_view, dst_view);
-    };
-
-    copy_row(cpu_ffn_gate, gpu_ffn_gate_cache);
-    copy_row(cpu_ffn_up,   gpu_ffn_up_cache);
-    copy_row(cpu_ffn_down_t, gpu_ffn_down_t_cache);
-    
-    ggml_free(view_ctx);
+    // 从堆中提取 Top-K 组 (groups_to_ensure)
+    std::vector<int> groups_to_ensure;
+    groups_to_ensure.reserve(this->layer_group_capacity);
+    while (!min_heap.empty()) {
+        groups_to_ensure.push_back(min_heap.top().second); // .second 是 group_id
+        min_heap.pop();
+    }
+    return groups_to_ensure;
 }
 
-void sparkInfer_layer_cache:: update_mappings(int64_t neuron_idx, int64_t slot_idx) {
-    neuron_to_slot_map[neuron_idx] = slot_idx;
-    slot_to_neuron_map[slot_idx] = neuron_idx;
+/**
+ * @brief [Plan Step 3] 计算差集并更新状态。
+ * @param groups_to_ensure Step 2 的结果。
+ * @return reload_plan_result 包含 plan_result.groups_to_reload 和 plan_result.slots_for_evict。
+ */
+const reload_plan_result & sparkInfer_layer_cache::_spif_reload_plan_compute_diff_and_update_state(const std::vector<int>& groups_to_ensure) {
+    // Clear previous plan results
+    this->plan_result.groups_to_reload.clear();
+    this->plan_result.slots_for_evict.clear();
+
+    // 1. O(k) 建立目标组的哈希集合
+    std::unordered_set<int> target_groups(groups_to_ensure.begin(), groups_to_ensure.end());
+
+    // 2. O(k) 遍历当前 GPU 上的组 (group_to_slot_hash)
+    //    找出 Hit (保留), Miss (需驱逐)
+    std::vector<int> groups_to_evict;
+    
+    for (auto it = this->group_to_slot_hash.begin(); it != this->group_to_slot_hash.end(); /* no increment */) {
+        int group_in_gpu = it->first;
+        int slot_id      = it->second;
+
+        if (target_groups.find(group_in_gpu) == target_groups.end()) {
+            // Miss: 在 GPU, 但不在 Target -> 驱逐
+            groups_to_evict.push_back(group_in_gpu);
+            this->plan_result.slots_for_evict.push_back(slot_id);
+            
+            // 更新状态: 从哈希表中移除
+            it = this->group_to_slot_hash.erase(it);
+        } else {
+            // Hit: 在 GPU, 也在 Target -> 保留
+            it++;
+        }
+    }
+
+    // 3. O(k) 遍历目标组, 找出需要新加载的组
+    for (const int group_id : target_groups) {
+        if (this->group_to_slot_hash.find(group_id) == this->group_to_slot_hash.end()) {
+            // 在 Target, 但不在 GPU (哈希表) -> 加载
+            this->plan_result.groups_to_reload.push_back(group_id);
+        }
+    }
+
+    // 4. 关键断言：空出的槽位必须等于需要加载的组
+    GGML_ASSERT(this->plan_result.slots_for_evict.size() == this->plan_result.groups_to_reload.size());
+
+    // 5. 更新状态: 将新加载的组“放回”哈希表，复用空闲 slot
+    for (size_t i = 0; i < this->plan_result.groups_to_reload.size(); ++i) {
+        int group_to_load = this->plan_result.groups_to_reload[i];
+        int slot_to_use   = this->plan_result.slots_for_evict[i]; // 复用被驱逐的 slot
+        
+        this->group_to_slot_hash[group_to_load] = slot_to_use;
+    }
+
+    return this->plan_result;
 }
 
+// --- sparkInfer_cache_manager Implementation ---
 
+sparkInfer_cache_manager::~sparkInfer_cache_manager() {
+    for (auto layer_cache : layer_caches) {
+        if (layer_cache) {
+            delete layer_cache;
+        }
+    }
+}
 
 bool sparkInfer_cache_manager:: init(llama_model &p_model, ggml_backend_t gpu_backend) {
     this->model = &p_model;
@@ -312,8 +226,9 @@ bool sparkInfer_cache_manager:: init(llama_model &p_model, ggml_backend_t gpu_ba
     return true;
 }
 
+/*
 void sparkInfer_cache_manager:: prepare_hot_neurons(int layer_idx, const std::vector<int64_t>& required_neuron_indices, std::vector<int64_t>& out_gpu_slot_indices) {
-    if (layer_caches[layer_idx]->neuron_cache_capacity == 0) return;
+    if (layer_caches[layer_idx]->layer_neuron_capacity == 0) return;
 
     out_gpu_slot_indices.resize(required_neuron_indices.size());
     for (size_t i = 0; i < required_neuron_indices.size(); ++i) {
@@ -325,7 +240,7 @@ void sparkInfer_cache_manager:: prepare_hot_neurons(int layer_idx, const std::ve
     // struct ggml_tensor* graph_neu_idx = model->layers[layer_idx].ffn_gpu_neu_idx;
     // ggml_backend_tensor_set(graph_neu_idx, out_gpu_slot_indices.data(), 0, sizeof(int32_t) * out_gpu_slot_indices.size());
 }
-
+*/
 
 
 sparkinfer_split_loader:: sparkinfer_split_loader(const std::string & fname) : fname(fname) {

--- a/src/llama-sparkinfer.cpp
+++ b/src/llama-sparkinfer.cpp
@@ -10,6 +10,176 @@ sparkInfer_layer_cache::~sparkInfer_layer_cache() {
 }
 
 // [YPX] [C] Init function is replaced by the constructor, which has not been merged yet.
+bool sparkInfer_layer_cache:: init(int layer_idx, llama_model& model, llama_layer& layer, ggml_backend_t backend, const std::vector<int64_t>& initial_gpu_neu_idx) {
+    bool has_gate = true; // GTODO: gate diverage
+    bool full_gpu = layer.gpu_offload_ratio >= 1;
+
+    // init backend
+    gpu_backend             = backend;
+    cpu_backend             = ggml_backend_cpu_init();
+
+    // cpu side tensors
+    cpu_ffn_gate            = has_gate ? layer.ffn_gate : nullptr;
+    cpu_ffn_up              = layer.ffn_up;
+    cpu_ffn_down_t          = layer.ffn_down_t;
+
+    // mappings
+    ffn_gpu_neu_idx             = layer.ffn_gpu_neu_idx;
+    ffn_gpu_neu_mask            = layer.ffn_gpu_neu_mask;
+    ffn_gpu_group_idx           = layer.ffn_gpu_group_idx;
+    ffn_gpu_group_mask          = layer.ffn_gpu_group_mask;
+    ffn_neuron_to_group_map     = layer.ffn_neuron_to_group_map;
+    
+    // metadata
+    layer_neuron_count      = model.layer_neuron_count; // 每层神经元总数
+    layer_group_size        = model.layer_group_size; // 每层分组大小
+    layer_group_count       = model.layer_group_count; // 每层分组数量
+    neuron_cache_capacity   = initial_gpu_neu_idx.size();
+    if (neuron_cache_capacity == 0) return true; // 无需卸载
+
+    // init DRF_score from ffn_gpu_neu_mask, simply cpy the mask to score with int64_t to float conversion
+    // maybe we coulf optimize this later
+    if(!full_gpu){
+        struct ggml_init_params params = { ggml_tensor_overhead() * 2, NULL, true };
+        tmp_ctx = ggml_init(params);
+        dfr_score = ggml_new_tensor_1d(tmp_ctx, GGML_TYPE_F32, ffn_gpu_neu_mask->ne[0]);
+        ggml_set_name(dfr_score, (std::string("blk.") + std::to_string(layer_idx) + std::string(".ffn_dfr_score")).c_str());
+
+        // alloc buffer for dfr_score
+        ggml_backend_buffer_t dfr_score_buffer = ggml_backend_alloc_buffer(cpu_backend, ggml_nbytes(dfr_score));
+        if (!dfr_score_buffer) {
+            LLAMA_LOG_ERROR("%s: failed to allocate CPU buffer for dfr_score\n", __func__);
+            return false;
+        }
+        ggml_backend_tensor_alloc(dfr_score_buffer, dfr_score, ggml_backend_buffer_get_base(dfr_score_buffer));
+
+        const int64_t n_mask = ffn_gpu_neu_mask->ne[0];
+        int64_t * mask_data = (int64_t*)ffn_gpu_neu_mask->data;
+        float * score_data = new float[ffn_gpu_neu_mask->ne[0]];
+        for(int64_t i=0; i<n_mask; i++){
+            score_data[i] = (float)(mask_data[i]);
+        }
+        ggml_backend_tensor_set(dfr_score, score_data, 0, ggml_nbytes(dfr_score));  // if we could get buffer from score directly, we could optimize this by direct cpy
+        delete[] score_data;
+    }
+
+    /* debug info */ 
+    // FILE* log_file = fopen("debug_split_info.log", "a");
+    // if (log_file == NULL) {
+    //     // 如果文件打开失败，可以打印一个错误到 stderr 然后继续，或者直接退出
+    //     perror("Failed to open log file");
+    //     // return; // 或者根据你的错误处理逻辑决定是否返回
+    // }
+    // std::time_t result = std::time(nullptr);
+    // fprintf(log_file, "\n--- Debugging Layer %d split info into file, timestamp %s ---", layer_idx, std::ctime(&result)); // 添加一些上下文信息
+    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_neu_idx);
+    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_neu_mask);
+    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_group_idx);
+    // debug_print_tensor_i64_to_file(log_file, ffn_gpu_group_mask);
+    // debug_print_tensor_i64_to_file(log_file, ffn_neuron_to_group_map);
+    // fflush(log_file);
+    // fclose(log_file);
+    /* debug info end */ 
+
+    GGML_ASSERT(neuron_cache_capacity <= layer_neuron_count && "we required neuron_cache_capacity <= layer_neuron_count");
+
+    // 1. 计算并分配ffn buffer size
+    const size_t single_mat_size = ggml_backend_buft_get_alloc_size(
+        ggml_backend_get_default_buffer_type(gpu_backend),
+        cpu_ffn_down_t // 使用其中一个矩阵作为尺寸参考
+    );
+    // 我们只缓存部分行，所以要按比例计算
+    const size_t single_cache_size = (single_mat_size / layer_neuron_count) * neuron_cache_capacity;
+    
+    // 总大小 = 3个矩阵的缓存大小之和
+    const size_t total_gpu_buffer_size = single_cache_size * 3;
+
+    gpu_weights_buffer = ggml_backend_alloc_buffer(gpu_backend, total_gpu_buffer_size);
+    if (!gpu_weights_buffer) {
+        LLAMA_LOG_ERROR("%s: failed to allocate GPU buffer for layer cache\n", __func__);
+        return false;
+    }
+
+    // 2. 在GPU缓存池中创建代表缓存张量
+    struct ggml_init_params params = { ggml_tensor_overhead() * 6, NULL, true };
+    tmp_ctx = ggml_init(params);
+
+    void* current_addr = ggml_backend_buffer_get_base(gpu_weights_buffer);
+    
+    char gate_name[64];
+
+    if(has_gate) {
+        gpu_ffn_gate_cache = ggml_new_tensor_2d(tmp_ctx, cpu_ffn_gate->type, cpu_ffn_gate->ne[0], neuron_cache_capacity);
+        snprintf(gate_name, sizeof(gate_name), "blk.%d.ffn_gpu_gate.weight", layer_idx);
+        ggml_set_name(gpu_ffn_gate_cache, gate_name);
+        ggml_backend_tensor_alloc(gpu_weights_buffer, gpu_ffn_gate_cache, current_addr);
+        current_addr = (char*)current_addr + single_cache_size;
+    }
+
+    gpu_ffn_up_cache = ggml_new_tensor_2d(tmp_ctx, cpu_ffn_up->type, cpu_ffn_up->ne[0], neuron_cache_capacity);
+    snprintf(gate_name, sizeof(gate_name), "blk.%d.ffn_gpu_up.weight", layer_idx);
+    ggml_set_name(gpu_ffn_up_cache, gate_name);
+    ggml_backend_tensor_alloc(gpu_weights_buffer, gpu_ffn_up_cache, current_addr);
+    current_addr = (char*)current_addr + single_cache_size;
+
+    gpu_ffn_down_t_cache = ggml_new_tensor_2d(tmp_ctx, cpu_ffn_down_t->type, cpu_ffn_down_t->ne[0], neuron_cache_capacity);
+    snprintf(gate_name, sizeof(gate_name), "blk.%d.ffn_gpu_down_t.weight", layer_idx);
+    ggml_set_name(gpu_ffn_down_t_cache, gate_name);
+    ggml_backend_tensor_alloc(gpu_weights_buffer, gpu_ffn_down_t_cache, current_addr);
+    
+    // 将新的GPU缓存张量赋给llama_layer
+    layer.ffn_gpu_gate = has_gate ? gpu_ffn_gate_cache : nullptr;
+    layer.ffn_gpu_up   = gpu_ffn_up_cache;
+    layer.ffn_gpu_down_t = gpu_ffn_down_t_cache;
+
+    // 3. init slot_to_neuron_map from ffn_gpu_neu_idx, and copy data to buffer
+    auto t_start = ggml_time_ms();
+    slot_to_neuron_map.resize(neuron_cache_capacity, -1);
+
+    auto batch_copy_neurons = [&](ggml_tensor* cpu_src, ggml_tensor* gpu_dst_cache, const std::vector<int64_t>& indices, const bool full_gpu) {
+        if(full_gpu){
+            const size_t full_tensor_bytes = ggml_nbytes(cpu_src);
+            ggml_backend_tensor_set(gpu_dst_cache, cpu_src->data, 0, full_tensor_bytes);
+        }else{
+            const int64_t n_embd = cpu_src->ne[0];
+            const size_t row_size_bytes = ggml_row_size(cpu_src->type, n_embd);
+            
+            // 在CPU上分配一个临时暂存缓冲区
+            std::vector<char> staging_buffer(row_size_bytes * indices.size());
+            
+            for (size_t i = 0; i < indices.size(); ++i) {
+                const int64_t neuron_idx = indices[i];
+                
+                // 源地址：在完整CPU张量中的位置
+                char* src_ptr = (char*)cpu_src->data + neuron_idx * cpu_src->nb[1];
+                
+                // 目标地址：在暂存缓冲区中的位置
+                char* dst_ptr = staging_buffer.data() + i * row_size_bytes;
+                
+                memcpy(dst_ptr, src_ptr, row_size_bytes);
+            }
+            
+            ggml_backend_tensor_set(gpu_dst_cache, staging_buffer.data(), 0, staging_buffer.size());
+        }
+    };
+
+    if(has_gate) batch_copy_neurons(cpu_ffn_gate, gpu_ffn_gate_cache, initial_gpu_neu_idx, full_gpu);
+    batch_copy_neurons(cpu_ffn_up, gpu_ffn_up_cache, initial_gpu_neu_idx, full_gpu);
+    batch_copy_neurons(cpu_ffn_down_t, gpu_ffn_down_t_cache, initial_gpu_neu_idx, full_gpu);
+
+    // 更新元数据
+    offloaded_bytes += ggml_nbytes(gpu_ffn_up_cache) * (has_gate ? 3 : 2); // 每个神经元有3个矩阵
+    for (size_t i = 0; i < initial_gpu_neu_idx.size(); ++i) {
+        int64_t neuron_idx = initial_gpu_neu_idx[i];
+        int64_t slot_idx = i;
+        update_mappings(neuron_idx, slot_idx);
+    }
+
+    auto t_end = ggml_time_ms();
+    LLAMA_LOG_INFO("%s: layer %d offload in %lld ms, cached %d neurons %s\n", __func__, layer_idx, t_end - t_start, neuron_cache_capacity, full_gpu?"(full_gpu)":" ");
+
+    return true;
+}
 
 // Sparkinfer reload (graph building)
 ggml_tensor * sparkInfer_layer_cache::build_reload_plan(ggml_context * ctx, ggml_tensor * sparse_idx, const int il){
@@ -659,13 +829,13 @@ ggml_tensor * sparkInfer_layer_cache:: build_reload_exec(ggml_context * ctx, ggm
 extern "C" {  
     bool ggml_spif_reload_plan(ggml_spif_context* ctx, ggml_tensor * tensor) {  
         sparkInfer_layer_cache * spif_cache = reinterpret_cast<sparkInfer_layer_cache*>(ctx);  
-        return spif_cache->spif_reload_plan(tensor);  
+        return spif_cache->spif_reload_plan(tensor);
     }
 
     bool ggml_spif_reload_exec(ggml_spif_context* ctx, ggml_tensor * tensor) {  
         sparkInfer_layer_cache * spif_cache = reinterpret_cast<sparkInfer_layer_cache*>(ctx);  
-        return spif_cache->spif_reload_exec(tensor);  
-    }  
+        return spif_cache->spif_reload_exec(tensor);
+    }
 }
 
 // Sparkinfer reload plan (算子 1 + 2)

--- a/src/llama-sparkinfer.h
+++ b/src/llama-sparkinfer.h
@@ -1,9 +1,9 @@
 #pragma once
 
- #include "llama-model.h"
- #include "llama-impl.h"
- #include "llama-model-loader.h"
- #include "ggml-spif.h"
+#include "llama-model.h"
+#include "llama-impl.h"
+#include "llama-model-loader.h"
+#include "ggml-spif.h"
 
 #include <algorithm>
 #include <cassert>
@@ -23,61 +23,87 @@
 #include <list>
 #include <omp.h>
 #include <inttypes.h>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+#include <list>  // LRU list
+#include <queue> // DFR priority_queue
+#include <set>   // set difference
 
+enum class sparkinfer_reload_strategy : int {
+    USE_DFR = 0,
+    USE_LRU = 1,
+    USE_FIFO = 2,
+    USE_OPT = 3,
+    USE_CLOCK = 4,
+    USE_NRU = 5,
+    USE_PLACEHOLDER = 6,
+};
 
- /*
- * @brief 管理单个层中FFN权重神经元的GPU缓存。
- * 
- * 负责在GPU上为部分卸载的神经元分配固定大小的缓存，并处理动态的换入换出操作。
- */
+// ==================================================================================================
+//                                      !!! 全局唯一的控制开关 !!!
+//                          通过修改这个值，然后重新编译，即可切换所有相关算子的行为
+constexpr sparkinfer_reload_strategy SPARKINFER_RELOAD_STRATEGY = sparkinfer_reload_strategy::USE_DFR;
+// ==================================================================================================
+
+/*
+* @brief 管理单个层中FFN权重神经元组的GPU缓存。
+*/
 struct sparkInfer_layer_cache {
 
+public:
+
+    // --- 后端与上下文 ---
     ggml_backend_t gpu_backend = nullptr;
     ggml_backend_t cpu_backend = nullptr;
+    struct ggml_context* tmp_ctx = nullptr; // 用于创建临时视图
 
-    // 指向CPU上的完整FFN权重张量（数据源）
-    struct ggml_tensor * cpu_ffn_gate = nullptr;
-    struct ggml_tensor * cpu_ffn_up   = nullptr;
+    // --- CPU 权重 (数据源) ---
+    struct ggml_tensor * cpu_ffn_gate   = nullptr;
+    struct ggml_tensor * cpu_ffn_up     = nullptr;
     struct ggml_tensor * cpu_ffn_down_t = nullptr;
 
-    // offloaded ffn neuron bufferr
+    // --- GPU 缓存池 (目标) ---
     ggml_backend_buffer_t gpu_weights_buffer = nullptr;
-    // gpu split index buffers
-    std::vector<ggml_backend_buffer_t> split_idx_allocated_buffers;
-
-    // 代表GPU缓存池中所有槽位的张量
-    struct ggml_tensor* gpu_ffn_gate_cache = nullptr;
-    struct ggml_tensor* gpu_ffn_up_cache   = nullptr;
+    struct ggml_tensor* gpu_ffn_gate_cache   = nullptr;
+    struct ggml_tensor* gpu_ffn_up_cache     = nullptr;
     struct ggml_tensor* gpu_ffn_down_t_cache = nullptr;
 
-    // ffn sparse inference relevant
-    struct ggml_tensor * ffn_gpu_neu_idx          = nullptr; // on gpu
-    struct ggml_tensor * ffn_gpu_neu_mask         = nullptr;
-    struct ggml_tensor * ffn_gpu_group_idx        = nullptr; // on gpu
-    struct ggml_tensor * ffn_gpu_group_mask       = nullptr;
-    struct ggml_tensor * ffn_neuron_to_group_map  = nullptr;
+    // --- 稀疏预测相关张量 ---
+    struct ggml_tensor * sparse_idx         = nullptr; // 在 GPU 上, 每次 plan 前需要从 GPU 同步
+    struct ggml_tensor * ffn_gpu_neu_idx    = nullptr; // 在 GPU 上
+    struct ggml_tensor * ffn_gpu_neu_mask   = nullptr; // 在 GPU 上
 
-    int64_t neuron_cache_capacity = 0; // GPU缓存池能容纳的神经元数量
-    uint64_t layer_neuron_count = 0; // 每层神经元总量
-    uint64_t layer_group_count = 0; // 每层分组总量
-    uint64_t layer_group_size = 0; // 每层分组大小
+    // --- (待清理) 多 GPU 遗留? ---
+    // [YPX] [Todo] 这很可能是多GPU split用的，待团队确认是否可移除
+    std::vector<ggml_backend_buffer_t> split_idx_allocated_buffers;
+
+    // --- 核心超参数 ---
+    int layer_neuron_count     = 0; // 每层神经元总量
+    int layer_group_count      = 0; // 每层分组总量
+    int layer_group_size       = 0; // 每层分组大小
+    int layer_group_capacity   = 0; // GPU缓存池能容纳的分组数量
     
-    // mappings
-    std::unordered_map<int64_t, int64_t> neuron_to_slot_map; // 原始神经元索引 -> GPU缓存槽位索引
-    std::vector<int64_t> slot_to_neuron_map; // GPU缓存槽位索引 -> 原始神经元索引
+    // --- 状态映射 (核心) ---
+    std::unordered_map<int, int> group_to_slot_hash; // group_id -> slot_id
+
+    // --- Reload Plan Result (核心) ---
+    reload_plan_result plan_result;
 
     // 实现LRU(最近最少使用)的替换策略，存储的是【原始神经元索引】, ofc we dont use lru, remove later
-    std::list<int64_t> lru_tracker;
-    std::unordered_map<int64_t, std::list<int64_t>::iterator> lru_map;
+    // std::list<int64_t> lru_tracker;
+    // std::unordered_map<int64_t, std::list<int64_t>::iterator> lru_map;
 
-    // DFR 
-    struct ggml_tensor* dfr_score = nullptr;
-    float decay_ratio = 0.9f;
+    // --- DFR 替换策略状态 ---
+    std::vector<float> dfr_scores; // size = layer_group_count
+    float dfr_decay_rate = 0.9f;
 
-    // 临时的ggml上下文，用于创建视图等临时张量
-    struct ggml_context* tmp_ctx = nullptr;
-
+    // --- 统计信息 ---
+    size_t reload_group_count=0;
     size_t offloaded_bytes=0;
+
+public:
 
     sparkInfer_layer_cache() = default;
     ~sparkInfer_layer_cache();
@@ -95,29 +121,65 @@ struct sparkInfer_layer_cache {
     // Sparkinfer reload (graph building)
     ggml_tensor * build_reload_plan(ggml_context * ctx, ggml_tensor * sparse_idx, const int il);
     ggml_tensor * build_reload_exec(ggml_context * ctx, ggml_tensor * sparse_idx, const char * name, const int il);
-    
+
     // Sparkinfer reload (real implementation)
     bool spif_reload_plan(ggml_tensor * tensor);
     bool spif_reload_exec(ggml_tensor * tensor);
 
     /**
-     * @brief 确保一个神经元在GPU上。如果不在，就执行换入操作。
-     * 
-     * @param neuron_idx 神经元的原始索引。
-     * @return int32_t 神经元在GPU缓存中的槽位索引。
+     * @brief (核心逻辑) 计算 reload plan。
+     * 由 GGML_RELOAD_PLAN 的 CUDA 算子函数调用。假设该算子已经执行了 sparse_idx 从 GPU 到 CPU 的拷贝。
+     * 步骤：
+     * 1. 计算 Top-K (groups_to_ensure)
+     * 2. 计算与当前状态的差集
+     * 3. 原子地更新内部的 group_to_slot_hash
+     * 4. 返回需要执行的 reload/evict plan
+     * @return reload_plan_result 包含 groups_to_reload 和 slots_for_evict
      */
-    int64_t ensure_neuron_on_gpu(int64_t neuron_idx);
+    const reload_plan_result & spif_reload_plan(){
+        // 确保 sparse_idx 的后端在 CPU 上
+        GGML_ASSERT(ggml_backend_get_backend(sparse_idx->backend) == GGML_BACKEND_CPU, "[Error] sparse_idx tensor must be on CPU backend before planning reload.");
+        // 1. 第一步：执行 `_spif_reload_plan_count_activated_neurons()`，得到 `group_activated_neurons_count` 数组
+        // 2. 第二步：执行 `_spif_reload_plan_get_groups_to_ensure()`，得到 `groups_to_ensure` 数组
+        // 3. 第三步：执行 `_spif_reload_plan_compute_diff_and_update_state()`，计算差集并更新状态
+        return _spif_reload_plan_compute_diff_and_update_state(_spif_reload_plan_get_groups_to_ensure(_spif_reload_plan_count_activated_neurons()));
+    }
 
 private:
     /**
-     * @brief 将一个神经元从CPU复制到GPU的指定slot。
-     */
-    void copy_neuron_to_gpu_slot(int64_t neuron_idx, int64_t slot_idx);
-    
-    /**
      * @brief 更新缓存的元数据。
      */
+    // [YPX] [B] 现在更新元数据（也就是这个类保管的张量）的工作应该由 Reload 算子的 compute_forward() 来负责，但是 init() 函数要调用这个，怎么办？干脆集成到 init() 函数里面算了。
+    // [YPX] [Todo] 把这个函数集成到 init() 里面。
     void update_mappings(int64_t neuron_idx, int64_t slot_idx);
+
+    /**
+     * @brief [Plan Step 1] 统计激活的神经元数量。
+     * @return std::vector<int> group_activated_neuron_count 每个组激活的神经元数量。
+     */
+    std::vector<int> _spif_reload_plan_count_activated_neurons();
+
+    /**
+     * @brief [Plan Step 2] 根据 DFR (或 LRU 等) 策略，计算出应在 GPU 上的 Top-K 组。
+     * @param group_activated_neuron_count Step 1 的结果。
+     * @return std::vector<int> groups_to_ensure 应该确保在 GPU 上的组列表。
+     */
+    std::vector<int> _spif_reload_plan_get_groups_to_ensure(const std::vector<int>& group_activated_neuron_count);
+
+    /**
+     * @brief [Plan Step 2.1] DFR 策略的具体实现。
+     */
+    std::vector<int> _spif_reload_plan_use_dfr(const std::vector<int>& group_activated_neuron_count, std::priority_queue<std::pair<float, int>, std::vector<std::pair<float, int>>, std::greater<std::pair<float, int>>>& min_heap);
+    
+    // [YPX] [Todo] 其他策略，比如 _spif_reload_plan_use_lru()
+
+    /**
+     * @brief [Plan Step 3] 计算差集并更新状态。
+     * @param groups_to_ensure Step 2 的结果。
+     * @return reload_plan_result 包含 groups_to_reload 和 slots_for_evict。
+     */
+    const reload_plan_result & _spif_reload_plan_compute_diff_and_update_state(const std::vector<int>& groups_to_ensure);
+
 };
 
 
@@ -126,11 +188,13 @@ private:
  *
  */
 struct sparkInfer_cache_manager {
+
+public:
+
+    // [YPX] [Q] 已知 compute_forward 全部都是用 C 语言写的，这里的 vector<sparkInfer_layer_cache*> 真的靠得住吗？
     std::vector<sparkInfer_layer_cache*> layer_caches;
     llama_model *model = nullptr;
     size_t total_offloaded_bytes=0;
-
-    bool init(llama_model &p_model, ggml_backend_t gpu_backend);
 
     /**
      * @brief 在推理前，准备好指定层所需的一组神经元。
@@ -139,7 +203,10 @@ struct sparkInfer_cache_manager {
      * @param required_neuron_indices 需要确保在GPU上的神经元原始索引列表。
      * @param out_gpu_slot_indices [输出参数] 填充更新后的GPU槽位索引，用于计算图。
      */
-    void prepare_hot_neurons(int layer_idx, const std::vector<int64_t>& required_neuron_indices, std::vector<int64_t>& out_gpu_slot_indices);
+    // [YPX] [C] 不需要了。
+    // void prepare_hot_neurons(int layer_idx, const std::vector<int64_t>& required_neuron_indices, std::vector<int64_t>& out_gpu_slot_indices);
+
+    bool init(llama_model &p_model, ggml_backend_t gpu_backend);
 };
 
 /**


### PR DESCRIPTION
This PR implements the reload plan and evict logic as member functions of `sparkInfer_layer_cache`, leveraging `op_params` to pass the `this` pointer from the ggml op. The core $O(k)$ DFR and state update logic is included.